### PR TITLE
Seems like libreadline isn't a thing anymore?

### DIFF
--- a/sites/en/installfest/linux.step
+++ b/sites/en/installfest/linux.step
@@ -22,8 +22,6 @@ Open a terminal (Applications > Accessories > Terminal).  You may want to right-
     libaprutil1
     libc6-dev
     libltdl-dev
-    libreadline6
-    libreadline6-dev
     libsqlite3-0
     libsqlite3-dev
     libssl-dev


### PR DESCRIPTION
I had to have an attendee remove these libs to get the deps install step to work. Thing seemed to work after that. Maybe we can get someone with a linux system to verify that this is the right path?